### PR TITLE
Volunteer-team-preference [QA] 

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,8 +4,7 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
     specPattern: 'e2e/integration/*.test.js',
-    supportFile: 'e2e/support/index.js',
-    defaultCommandTimeout: 10000
+    supportFile: 'e2e/support/index.js'
   },
   fixturesFolder: 'e2e/fixtures',
   screenshotsFolder: 'e2e/screenshots',

--- a/src/Components/forms/index.js
+++ b/src/Components/forms/index.js
@@ -18,7 +18,6 @@ class Forms extends Component {
 
   componentDidMount() {
     this.fetchTeamData()
-    this.props.loadCities()
   }
 
   fetchTeamData = async () => {


### PR DESCRIPTION
This is a:

<!-- Tick one category - if more than one applies, it should be split up -->

- [ ] ✨ **New feature** - new behaviour has been implemented
- [ ] 🐛 **Bug fix** - existing behaviour has been made to behave
- [ ] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ✅ **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
- [ ] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

<!-- adapted from https://gitmoji.dev/ -->

### Description

<!-- Describe what merging this pull request will do -->

- **Purpose** - <!-- Allow astronauts to perform a case-insensitive search for their spaceship. -->

<!-- Describe how the reviewer should check it works -->

- **How to check** - <!-- Log in as an astronaut, go to the Spaceships tab and type "saturn" into the search box. Previously Saturn V would not have appeared, due to the capital S, but now it does. -->

### Links

<!-- links to other issues/PRs/tickets, e.g. user/repo#123 -->

### Author checklist

<!-- All PRs -->

- [ ] I have written a title that reflects the relevant ticket
- [ ] I have written a description that says what the PR does and how to validate it
- [ ] I have linked to the project board ticket (and any related PRs/issues) in the Links section
- [ ] I have added a link to this PR to the ticket
- [ ] I have made the PR to `qa` from a branch named `<category>/<name>`, e.g. `feature/edit-spaceships` or `bugfix/restore-oxygen`
- [ ] I have completed the manual tests [described here](https://github.com/CodeYourFuture/tech-team/wiki/3.-How-we-work#manual-test-procedures)
- [ ] I have requested reviewers here and in my team chat channel
<!-- depending on the task, the following may be optional -->
- [ ] I have spoken with my PM or TL about any parts of this task that may have become out-of-scope, or any additional improvements that I now realise may benefit my project
- [ ] I have added tests, or new tests were not required
- [ ] I have updated any documentation (e.g. diagrams, schemas), or documentation updates were not required
