### PR TITLE
Bump word-wrap from 1.2.3 to 1.2.4 [MASTER]

### DIFF
--- a/src/Components/forms/index.js
+++ b/src/Components/forms/index.js
@@ -25,7 +25,7 @@ class Forms extends Component {
       const response = await axios.get(`${domain()}/teams`)
       const teamData = response.data.teams
       teamData.sort((a, b) => a.name.localeCompare(b.name))
-
+      teamData.push({ name: 'I am not sure' })
       this.setState({ teamOptions: teamData })
     } catch (err) {
       return this.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -10554,9 +10554,9 @@ widest-line@^4.0.1:
     string-width "^5.0.1"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
+  integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
 
 workbox-background-sync@6.5.4:
   version "6.5.4"


### PR DESCRIPTION
This is a:

<!-- Tick one category - if more than one applies, it should be split up -->

- [ ] ✨ **New feature** - new behaviour has been implemented
- [ ] 🐛 **Bug fix** - existing behaviour has been made to behave
- [X] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ✅ **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
- [ ] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

<!-- adapted from https://gitmoji.dev/ -->

### Description

<!-- Describe what merging this pull request will do -->

- **Purpose** - <!-- Allow astronauts to perform a case-insensitive search for their spaceship. -->
This ticket is for updating the word-wrap dependency from 1.2.3 to 1.2.4
<!-- Describe how the reviewer should check it works -->

- **How to check** - <!-- Log in as an astronaut, go to the Spaceships tab and type "saturn" into the search box. Previously Saturn V would not have appeared, due to the capital S, but now it does. -->
Run CYF form and check that it is working correctly. Also, check the dependency version and you should find that it has the 1.2.4 version.
### Links

<!-- links to other issues/PRs/tickets, e.g. user/repo#123 -->

### Author checklist

<!-- All PRs -->

- [x] I have written a title that reflects the relevant ticket
- [x] I have written a description that says what the PR does and how to validate it
- [x] I have linked to the project board ticket (and any related PRs/issues) in the Links section
- [x] I have added a link to this PR to the ticket
- [x] I have made the PR to `qa` from a branch named `<category>/<name>`, e.g. `feature/edit-spaceships` or `bugfix/restore-oxygen`
- [ ] I have completed the manual tests [described here](https://github.com/CodeYourFuture/tech-team/wiki/3.-How-we-work#manual-test-procedures)
- [x] I have requested reviewers here and in my team chat channel
<!-- depending on the task, the following may be optional -->
- [ ] I have spoken with my PM or TL about any parts of this task that may have become out-of-scope, or any additional improvements that I now realise may benefit my project
- [ ] I have added tests, or new tests were not required
- [ ] I have updated any documentation (e.g. diagrams, schemas), or documentation updates were not required
