### PR TITLE
Stop e2e tests failing

### DIFF
--- a/e2e/integration/withCode.test.js
+++ b/e2e/integration/withCode.test.js
@@ -7,6 +7,9 @@ beforeEach(() => {
   cy.intercept('GET', `${mockServerURL}/teams`, {
     fixture: 'teams.json'
   })
+  cy.intercept('GET', `${mockServerURL}/employers`, {
+    fixture: 'employers.json'
+  })
 })
 
 it('shows success message', () => {


### PR DESCRIPTION
This is a:

<!-- Tick one category - if more than one applies, it should be split up -->

- [ ] ✨ **New feature** - new behaviour has been implemented
- [ ] 🐛 **Bug fix** - existing behaviour has been made to behave
- [ ] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ✅ **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
- [x] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

<!-- adapted from https://gitmoji.dev/ -->

### Description

<!-- Describe what merging this pull request will do -->

- **Purpose** - 
- Discover the reason why the CircleCI e2e tests are failing and fix the problem.
- Found that a request to cyf-api was not being intercepted for the last batch of tests

<!-- Describe how the reviewer should check it works -->

- **How to check** - 
- This PR should pass the CircleCI tests 😁

### Links

[Issue 1023](https://github.com/CodeYourFuture/tech-team/issues/1023)

### Author checklist

<!-- All PRs -->

- [x] I have written a title that reflects the relevant ticket
- [x] I have written a description that says what the PR does and how to validate it
- [x] I have linked to the project board ticket (and any related PRs/issues) in the Links section
- [x] I have added a link to this PR to the ticket
- [x] I have made the PR to `qa` from a branch named `<category>/<name>`, e.g. `feature/edit-spaceships` or `bugfix/restore-oxygen`
- [x] I have completed the manual tests [described here](https://github.com/CodeYourFuture/tech-team/wiki/3.-How-we-work#manual-test-procedures)
- [x] I have requested reviewers here and in my team chat channel
<!-- depending on the task, the following may be optional -->
- [ ] I have spoken with my PM or TL about any parts of this task that may have become out-of-scope, or any additional improvements that I now realise may benefit my project
- [x] I have added tests, or new tests were not required
- [x] I have updated any documentation (e.g. diagrams, schemas), or documentation updates were not required
